### PR TITLE
Sample for DE vehicleignorelist.json

### DIFF
--- a/json/region/de/Sample_vehicleignorelist.json
+++ b/json/region/de/Sample_vehicleignorelist.json
@@ -1,0 +1,5 @@
+#Diese können beliebig zusammen kopiert werden. Ein Fahrzeug muss immer in "" stehen und durch ein Komma getrennt werden. Hier sind paar beispiele:
+
+["dhufükw", "elw 1 (seg)", "feuerwehrkräne (fwk)", "gw-a oder ab-atemschutz", "gw-a", "gw-gefahrgut", "gw-höhenrettung", "gw-mess", "gw-messtechnik", "gw-öl", "gw-san", "gw-taucher", "gw-wasserrettung", "kdow lna", "kdow orgl", "kdow-lna", "kdow-orgl", "lna", "orgl", "polizeihubschrauber", "rettungshundestaffel/n", "rettungshundestaffeln", "rth", "außenlastbehälter (allgemein)"]
+
+["elw 1 (seg)", "außenlastbehälter (allgemein)", "rth"]


### PR DESCRIPTION
All vehicles were always added to the missions. Where it is missing, it is gradually added.
So that new players or those who do not want to have all the vehicles have the opportunity to easily take these vehicles out again without touching the missions. This should only be used as a template for copying and pasting to these.